### PR TITLE
fix: date format busybox friendly

### DIFF
--- a/assume_role.sh
+++ b/assume_role.sh
@@ -73,7 +73,7 @@ determine_timeout(){
     OS_TYPE=$(uname -s)
     # linux specific
     if [ "$OS_TYPE" = Linux ]; then
-        export AWS_STS_TIMEOUT=$(date --date="$AWS_STS_EXPIRATION" "+%s")
+        export AWS_STS_TIMEOUT=$(date --date="$(echo $AWS_STS_EXPIRATION | sed -e 's/T/\ /g' -e 's/Z$//g')" "+%s")
     # mac specific
     elif [ "$OS_TYPE" = Darwin ]; then
         export AWS_STS_TIMEOUT=$(date -ujf "%Y-%m-%dT%H:%M:%SZ" "$AWS_STS_EXPIRATION" "+%s") # reassign var to epoch timestamp


### PR DESCRIPTION
Fix incompatibility with date command not able to parse [ISO_8601's "Zulu time"](https://en.wikipedia.org/wiki/ISO_8601#Coordinated_Universal_Time_(UTC)) formatting that AWS's [sts assume-role](https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html#examples) output utilizes. Issues using docker containers that use busybox's date command were directly impacted.

Error example:
`date: invalid date '2020-01-16T00:00:17Z'`